### PR TITLE
retrieve uncached form when form state not yet cached.

### DIFF
--- a/Ahah.inc
+++ b/Ahah.inc
@@ -40,10 +40,17 @@ class Ahah {
     $form_build_id = $_REQUEST['form_build_id'];
     $form_state = array('storage' => NULL, 'submitted' => FALSE, 'post' => $_POST);
     if (!$form = form_get_cache($form_build_id, $form_state)) {
+      if ($form_id = $form_state['post']['form_id']) {
+        $form = drupal_retrieve_form($form_id, $form_state);
+      }
+    }
+    if (!$form) {
       self::cancelResponse();
     }
     module_load_include('inc', 'node', 'node.pages'); // Need for using AHAH in conjunction with Node API.
-    $form_id = array_shift($form['#parameters']);
+    if(!$form_id) {
+      $form_id = array_shift($form['#parameters']);
+    }
     return array($form_id, $form_build_id, &$form, &$form_state);
   }
 


### PR DESCRIPTION
This change attempts to load a form with drupal_retrieve_form when a cached form is not found by form_get_cache.  This was causing a small error when a user backed up (i.e. with the browser's back button) onto a form whose build state was no longer cached.  instead of giving the user annoying javascript messages, we reload the form using the current form state.

A short screencast exposing a minor bug:
http://youtu.be/Oj4CZu8Xo_8

If I'm going about this the wrong way, please let me know.
