### PR TITLE
ISLANDORA-2248: Prevent PHP Strict standards issue

### DIFF
--- a/xml/XMLDocument.inc
+++ b/xml/XMLDocument.inc
@@ -226,7 +226,7 @@ class _XMLDocument extends DOMDocument {
   /**
    * Removed function.
    */
-  public function loadHTMLFile($filename) {
+  public function loadHTMLFile($filename, $options = NULL) {
     throw new Exception(__FUNCTION__ . ' is not supported.');
   }
 


### PR DESCRIPTION
**JIRA Ticket**: https://jira.duraspace.org/browse/ISLANDORA-2248

# What does this Pull Request do?

Avoid
```
PHP Strict standards:  Declaration of _XMLDocument::loadHTMLFile() should be compatible with DOMDocument::loadHTMLFile($source, $options = NULL) in xml/XMLDocument.inc on line 252
```
in PHP 5.4+ (note that this error has been observed also in TravisCI's _build_ step).

# What's new?

Update signature of `_XMLDocument::loadHTMLFile()` to account for optional `$options` argument introduced in PHP 5.4 (see [JIRA ticket](https://jira.duraspace.org/browse/ISLANDORA-2248) for more background).

# How should this be tested?

Execute
```sh
php -l -d error_reporting=-1 xml/XMLDocument.inc
```
inside the _PHP Lib_ module directory (`/var/www/drupal/sites/all/modules/php_lib` on standard vagrant VM). _Before_ this PR, you would see the aforementioned error, _after_ this PR, you should see
```
No syntax errors detected in xml/XMLDocument.inc
```
Alternatively, check that this PR passes TravisCI (check logs!).

# Additional Notes:

* Does this change require documentation to be updated? _no_
* Does this change add any new dependencies? _no_
* Does this change require any other modifications to be made to the repository (ie. Regeneration activity, etc.)? _no_
* Could this change impact execution of existing code? _no_

# Interested parties
@DiegoPino @Islandora/7-x-1-x-committers
